### PR TITLE
allow running of TestCsrfMiddleware tests in isolation

### DIFF
--- a/session_csrf/tests.py
+++ b/session_csrf/tests.py
@@ -80,6 +80,10 @@ class TestCsrfMiddleware(django.test.TestCase):
         cache.set(self.token, 'woo')
         request = rf.get('/')
         request.session = {}
+        r = {
+            'wsgi.input':      django.test.client.FakePayload('')
+        }
+        ClientHandler()(self.rf._base_environ(**r)) # hack to set up request middleware
         self.mw.process_request(request)
         self.assertEqual(request.csrf_token, 'woo')
 


### PR DESCRIPTION
http://paste.codebasehq.com/pastes/cqiietmujjohn7l0e5

if I run all the tests for the module it passes, if I single out `TestCsrfMiddleware` it fails

the number of tests run each way adds up though, so it's not skipping anything when I run all

I can see why it fails but I wasn't getting why it passes when you run them all. Now I see it's because the Django request middleware gets set up by `ClientHandler`if you run the other test classes, and this is necessary to have a `request.user` for the csrf middleware to check for.

So strictly speaking it seems like `TestCsrfMiddleware` should also set up request middleware, at least for the failing method that needs `request.user`.

I have made a hack for this here, not sure if it's the best way. (or could I just set a dummy `user` attribute on the request and leave it at that?)
