### PR TITLE
Don't recommend putting important code in manage.py.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,8 +45,8 @@ Then we have to monkeypatch Django to fix the ``@csrf_protect`` decorator::
     import session_csrf
     session_csrf.monkeypatch()
 
-Make sure that's in something like ``manage.py`` so the patch gets applied
-before your views are imported.
+Make sure that's in something like your root ``urls.py`` so the patch gets
+applied before your views are imported.
 
 
 Differences from Django


### PR DESCRIPTION
Currently the django-session-csrf README recommends putting the monkeypatch code in `manage.py`. Placing code that your project relies on to function in `manage.py` is an anti-pattern, as there is no reason to believe that `manage.py` will ever be executed in a production deployment of a Django app; in many common deployment setups it is not.

Fortunately there is a simple and equally functional alternative; if the monkeypatch is done in the root `urls.py` before the url patterns are declared, it will still take effect before views are imported. This pull request recommends that instead.
