### PR TITLE
Check for existence of request.user before calling is_authenticated()

### DIFF
--- a/session_csrf/__init__.py
+++ b/session_csrf/__init__.py
@@ -50,7 +50,7 @@ class CsrfMiddleware(object):
         """
         if hasattr(request, 'csrf_token'):
             return
-        if request.user.is_authenticated():
+        if hasattr(request, 'user') and request.user.is_authenticated():
             if 'csrf_token' not in request.session:
                 token = django_csrf._get_new_csrf_key()
                 request.csrf_token = request.session['csrf_token'] = token


### PR DESCRIPTION
There exists a race condition within the csrf middleware which causes AttributeError: 'WSGIRequest' object has no attribute 'user' when using Django's  contrib authentication middleware.

The issue is request.user is created by the Authentication middleware so it doesn't exist yet if you have CSRF middleware listed above the Auth middleware in MIDDLEWARE_CLASSES.

But the CSRF middleware must be placed above the Auth middleware otherwise you get CSRF token errors when attempting to login to the admin.

Adding an extra check that the user attribute exists on the request before checking for is_authenticated() resolves this error.