### PR TITLE
Remove `django` from `install_requires`

### DIFF
--- a/session_csrf/tests.py
+++ b/session_csrf/tests.py
@@ -2,7 +2,7 @@ import urllib
 
 import django.test
 from django import http
-from django.conf.urls.defaults import patterns
+from django.conf.urls import patterns
 from django.contrib.auth import logout
 from django.contrib.auth.middleware import AuthenticationMiddleware
 from django.contrib.auth.models import User

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ setup(
     license='BSD',
     packages=find_packages(),
     include_package_data=True,
-    install_requires=['django'],
     zip_safe=False,
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
*setup.py* was defining Django as a dependency. This causes it to be installed automatically if you `pip install django-session-csrf` (or `pip install` a requirements file including `django-session-csrf`).

This results in a mess of 2 copies installed over each other if using a fork of django (e.g. [django-nonrel](https://github.com/django-nonrel/django)), as pip doesn’t recognise them as the same dependency.

Surely projects which want to use django-session-csrf will already have Django: either already installed, or already in a requirements.txt file.

---

Also corrected a deprecated import path in tests.py, for compatibility with Django 1.6+ (as requirements.txt grabs the latest version of Django, tests fail without this, and I try not to raise PRs with failing tests!)
