### PR TITLE
Check if user object is set before calling is_authenticated on it.

### DIFF
--- a/session_csrf/__init__.py
+++ b/session_csrf/__init__.py
@@ -50,7 +50,7 @@ class CsrfMiddleware(object):
         """
         if hasattr(request, 'csrf_token'):
             return
-        if request.user.is_authenticated():
+        if hasattr(request, 'user') and request.user.is_authenticated():
             if 'csrf_token' not in request.session:
                 token = django_csrf._get_new_csrf_key()
                 request.csrf_token = request.session['csrf_token'] = token
@@ -81,7 +81,7 @@ class CsrfMiddleware(object):
             return
 
         if (getattr(view_func, 'anonymous_csrf_exempt', False)
-            and not request.user.is_authenticated()):
+            and not (hasattr(request, 'user') and request.user.is_authenticated())):
             return
 
         # Bail if this is a safe method.
@@ -125,7 +125,7 @@ def anonymous_csrf(f):
     """Decorator that assigns a CSRF token to an anonymous user."""
     @functools.wraps(f)
     def wrapper(request, *args, **kw):
-        use_anon_cookie = not (request.user.is_authenticated() or ANON_ALWAYS)
+        use_anon_cookie = not (hasattr(request, 'user') and request.user.is_authenticated()) and not ANON_ALWAYS
         if use_anon_cookie:
             if ANON_COOKIE in request.COOKIES:
                 key = request.COOKIES[ANON_COOKIE]


### PR DESCRIPTION
Without this change session_csrf crashes when you remove AuthenticationMiddleware from settings. session_csrf should not depend on it I think.