### PR TITLE
don't require django to install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ setup(
     license='BSD',
     packages=find_packages(),
     include_package_data=True,
-    install_requires=['django'],
     zip_safe=False,
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
A refresh from https://github.com/mozilla/django-session-csrf/pull/17 which has conflicts. 