### PR TITLE
Add a note about Django's CSRF_USE_SESSIONS

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,8 @@
+.. note::
+   Consider using Django's build-in `CSRF_USE_SESSIONS
+   <https://docs.djangoproject.com/en/1.11/ref/settings/#std:setting-CSRF_USE_SESSIONS>`_
+   feature available from Django v1.11.
+
 What is this?
 -------------
 


### PR DESCRIPTION
As @kravietz points out in #43, Django has it's own way to do this know. We should let the users know.

Maybe we should deprecate this library? /cc @peterbe @moggers87  r?